### PR TITLE
Refactor parsing in `kicad_rs`

### DIFF
--- a/tools/kicad_rs/src/error.rs
+++ b/tools/kicad_rs/src/error.rs
@@ -1,0 +1,24 @@
+use std::error::Error;
+use std::fmt;
+
+// A struct implementing the Error trait, carrying just a simple message
+#[derive(Debug)]
+pub struct StringError {
+    str: String,
+}
+
+pub fn errorf(s: &str) -> StringError {
+    StringError { str: s.into() }
+}
+
+impl fmt::Display for StringError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.str)
+    }
+}
+
+impl Error for StringError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}

--- a/tools/kicad_rs/src/lib.rs
+++ b/tools/kicad_rs/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod codec;
+pub mod error;
 pub mod parser;
 pub mod resolver;
 pub mod types;

--- a/tools/kicad_rs/src/parser.rs
+++ b/tools/kicad_rs/src/parser.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 use std::error::Error;
-use std::fmt;
 use std::path::Path;
 
 use kicad_parse_gen::schematic as kicad_schematic;
 
+use crate::error::errorf;
 use crate::types::*;
 
 type ParseResult<T> = Result<T, Box<dyn Error>>;
@@ -350,26 +350,5 @@ impl<T: AsRef<str>> SplitCharN for Option<T> {
             Some(s) => s.as_ref().split_char_n(split_char, idx),
             None => None,
         }
-    }
-}
-
-// A struct implementing the Error trait, carrying just a simple message
-#[derive(Debug)]
-struct StringError {
-    str: String,
-}
-
-fn errorf(s: &str) -> StringError {
-    StringError { str: s.into() }
-}
-
-impl fmt::Display for StringError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.str)
-    }
-}
-impl Error for StringError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        None
     }
 }


### PR DESCRIPTION
Continuation of #8 now that the common types and routines have been integrated from the `parser` side. Makes some necessary changes to help facilitate code sharing for the `evaluator`.

WIP, cc @luxas @chiplet 