### PR TITLE
Implement a KiCad component classifier

### DIFF
--- a/tools/kicad_rs/src/bin/classifier.rs
+++ b/tools/kicad_rs/src/bin/classifier.rs
@@ -1,0 +1,30 @@
+use kicad_rs::classifier::*;
+use kicad_rs::codec;
+use kicad_rs::error::DynamicResult;
+use kicad_rs::types::Schematic;
+use std::env;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+fn main() -> DynamicResult<()> {
+    // Read the Schematic YAML from stdin
+    let sch: Schematic = codec::unmarshal_yaml(io::stdin())?;
+
+    // Read the first argument as the path to the policy file
+    let args: Vec<String> = env::args().collect();
+    let p = Path::new(
+        args.get(1)
+            .ok_or("expected policy file as first argument")?,
+    );
+
+    // Read the policy file
+    let policy: Policy = codec::unmarshal_yaml(fs::File::open(&p)?)?;
+
+    // Transform the schematic using the defined policy
+    let sch = policy.apply(sch)?;
+
+    // Marshal the resulting schematic as YAML
+    codec::marshal_yaml(&sch, io::stdout())?;
+    Ok(())
+}

--- a/tools/kicad_rs/src/bin/parser.rs
+++ b/tools/kicad_rs/src/bin/parser.rs
@@ -1,18 +1,23 @@
 use kicad_rs::codec;
+use kicad_rs::error::DynamicResult;
 use kicad_rs::types::*;
 use std::env;
-use std::error::Error;
+use std::io;
 use std::path::Path;
 
 // Main function, can return different kinds of errors
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> DynamicResult<()> {
+    // Read the first argument as the path to the .sch file
     let args: Vec<String> = env::args().collect();
-    let p = Path::new(args.get(1).ok_or("expected file as first argument")?);
+    let p = Path::new(
+        args.get(1)
+            .ok_or("expected KiCad schematic file as first argument")?,
+    );
+
+    // Parse the schematic file
     let sch = Schematic::parse(&p)?;
 
     // Marshal as YAML
-    let serialized = codec::marshal_yaml(&sch)?;
-    println!("{}", serialized);
-
+    codec::marshal_yaml(&sch, io::stdout())?;
     Ok(())
 }

--- a/tools/kicad_rs/src/classifier.rs
+++ b/tools/kicad_rs/src/classifier.rs
@@ -1,0 +1,80 @@
+use crate::labels::LabelsMatch;
+use crate::requirements::Requirement;
+use crate::error::DynamicResult;
+use crate::types::{Component, Schematic};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::hash::Hash;
+use std::iter::FromIterator;
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct Policy {
+    classifiers: Vec<ComponentClassifier>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct ComponentClassifier {
+    // The class that shall be applied to a component matching these requirements
+    pub class: String,
+    // Labels matching
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub labels: Vec<Requirement>,
+    // Attribute matching
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub attributes: Vec<Requirement>,
+}
+
+impl Policy {
+    // apply applies the policy on a given Schematic
+    pub fn apply(&self, sch: Schematic) -> DynamicResult<Schematic> {
+        let mut sch = sch;
+        classify_components(&mut sch, &self.classifiers);
+        Ok(sch)
+    }
+}
+
+// classify_components recursively walks through a Schematic, and assigns the Component.classes field
+fn classify_components(sch: &mut Schematic, classifiers: &Vec<ComponentClassifier>) {
+    for comp in sch.components.iter_mut() {
+        comp.classes = classify_component(comp, classifiers);
+    }
+    for sch in sch.sub_schematics.iter_mut() {
+        classify_components(sch, classifiers);
+    }
+}
+
+// classify_component returns a list of classes for a given component, given the set of classifiers
+fn classify_component(comp: &Component, classifiers: &Vec<ComponentClassifier>) -> Vec<String> {
+    // Map all classifiers to their name if the component matches the classifier
+    let matched_classes: Vec<String> = classifiers
+        .iter()
+        .filter_map(|classifier| {
+            // Require that both all labels and attribute requirements match
+            if !classifier.labels.matches(&comp.labels.to_map()) {
+                return None;
+            }
+            if !classifier.attributes.matches(&comp.attributes) {
+                return None;
+            }
+
+            // If we get all the way here, we have "matched" with this class.
+            return Some(classifier.class.clone());
+        })
+        .collect();
+
+    // As there might be many classifiers of the same name that have matched with a component,
+    // filter all duplicates.
+    filter_duplicates(&matched_classes)
+}
+
+// filter_duplicates inserts all items into a HashSet, and builds a new vector without any duplicates
+fn filter_duplicates<T: Eq + Clone + Hash>(list: &Vec<T>) -> Vec<T> {
+    let f: HashSet<&T> = HashSet::from_iter(list.iter());
+    f.iter().map(|s| s.clone().to_owned()).collect()
+}

--- a/tools/kicad_rs/src/classifier.rs
+++ b/tools/kicad_rs/src/classifier.rs
@@ -69,7 +69,7 @@ fn classify_component(comp: &Component, classifiers: &Vec<ComponentClassifier>) 
         .collect();
 
     // As there might be many classifiers of the same name that have matched with a component,
-    // filter all duplicates.
+    // filter all duplicates
     filter_duplicates(&matched_classes)
 }
 

--- a/tools/kicad_rs/src/codec.rs
+++ b/tools/kicad_rs/src/codec.rs
@@ -1,3 +1,4 @@
+use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::io;
 
@@ -16,4 +17,13 @@ where
     serde_yaml::to_writer(writer, &json_val)?;
     // All ok
     Ok(())
+}
+
+// unmarshal_yaml is the reverse operation of marshal_yaml.
+pub fn unmarshal_yaml<R, T>(reader: R) -> serde_yaml::Result<T>
+where
+    R: io::Read,
+    T: DeserializeOwned,
+{
+    serde_yaml::from_reader(reader)
 }

--- a/tools/kicad_rs/src/codec.rs
+++ b/tools/kicad_rs/src/codec.rs
@@ -5,7 +5,7 @@ use std::io;
 use crate::error::DynamicResult;
 
 // marshal_yaml marshals a serializable value to a YAML string using Serde, but
-// avoiding https://github.com/dtolnay/serde-yaml/issues/87.
+// avoiding https://github.com/dtolnay/serde-yaml/issues/87
 pub fn marshal_yaml<T, W>(data: T, writer: W) -> DynamicResult<()>
 where
     T: Serialize,
@@ -19,7 +19,7 @@ where
     Ok(())
 }
 
-// unmarshal_yaml is the reverse operation of marshal_yaml.
+// unmarshal_yaml is the reverse operation of marshal_yaml
 pub fn unmarshal_yaml<R, T>(reader: R) -> serde_yaml::Result<T>
 where
     R: io::Read,

--- a/tools/kicad_rs/src/codec.rs
+++ b/tools/kicad_rs/src/codec.rs
@@ -1,13 +1,19 @@
 use serde::Serialize;
-use std::error::Error;
+use std::io;
+
+use crate::error::DynamicResult;
 
 // marshal_yaml marshals a serializable value to a YAML string using Serde, but
 // avoiding https://github.com/dtolnay/serde-yaml/issues/87.
-pub fn marshal_yaml<T: Serialize>(data: T) -> Result<String, Box<dyn Error>> {
+pub fn marshal_yaml<T, W>(data: T, writer: W) -> DynamicResult<()>
+where
+    T: Serialize,
+    W: io::Write,
+{
     // First use the JSON bin.parser to convert the struct into an "intermediate representation": a Serde::Value
     let json_val = serde_json::to_value(data)?;
     // Then, marshal the intermediate representation to YAML, avoiding errors like https://github.com/dtolnay/serde-yaml/issues/87
-    let serialized = serde_yaml::to_string(&json_val)?;
-    // Return the serialized string
-    Ok(serialized)
+    serde_yaml::to_writer(writer, &json_val)?;
+    // All ok
+    Ok(())
 }

--- a/tools/kicad_rs/src/error.rs
+++ b/tools/kicad_rs/src/error.rs
@@ -1,6 +1,9 @@
 use std::error::Error;
 use std::fmt;
 
+// A result that can carry any Error implementation
+pub type DynamicResult<T> = Result<T, Box<dyn Error>>;
+
 // A struct implementing the Error trait, carrying just a simple message
 #[derive(Debug)]
 pub struct StringError {

--- a/tools/kicad_rs/src/labels.rs
+++ b/tools/kicad_rs/src/labels.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
-// Labels is a trait describing a string-string of labels describing some object.
+// Labels is a trait describing a string-string of labels describing some object
 pub trait Labels {
     fn get_label(&self, key: &str) -> Option<&str>;
 }
 
 // LabelsMatch is a trait that allows deciding whether a given requirement matches
-// the set of labels given.
+// the set of labels given
 pub trait LabelsMatch {
     fn matches<L: Labels>(&self, labels: &L) -> bool;
 }

--- a/tools/kicad_rs/src/labels.rs
+++ b/tools/kicad_rs/src/labels.rs
@@ -1,0 +1,19 @@
+use std::collections::HashMap;
+
+// Labels is a trait describing a string-string of labels describing some object.
+pub trait Labels {
+    fn get_label(&self, key: &str) -> Option<&str>;
+}
+
+// LabelsMatch is a trait that allows deciding whether a given requirement matches
+// the set of labels given.
+pub trait LabelsMatch {
+    fn matches<L: Labels>(&self, labels: &L) -> bool;
+}
+
+// Implement the Labels trait for a string-string HashMap
+impl Labels for HashMap<&str, &str> {
+    fn get_label(&self, key: &str) -> Option<&str> {
+        self.get(key).map(|s| s.to_owned())
+    }
+}

--- a/tools/kicad_rs/src/lib.rs
+++ b/tools/kicad_rs/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod classifier;
 pub mod codec;
 pub mod error;
 pub mod labels;

--- a/tools/kicad_rs/src/lib.rs
+++ b/tools/kicad_rs/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod codec;
 pub mod error;
+pub mod labels;
 pub mod parser;
 pub mod resolver;
 pub mod types;

--- a/tools/kicad_rs/src/lib.rs
+++ b/tools/kicad_rs/src/lib.rs
@@ -2,5 +2,6 @@ pub mod codec;
 pub mod error;
 pub mod labels;
 pub mod parser;
+pub mod requirements;
 pub mod resolver;
 pub mod types;

--- a/tools/kicad_rs/src/parser.rs
+++ b/tools/kicad_rs/src/parser.rs
@@ -1,22 +1,18 @@
+use kicad_parse_gen::schematic as kicad_schematic;
 use std::collections::HashMap;
-use std::error::Error;
 use std::path::Path;
 
-use kicad_parse_gen::schematic as kicad_schematic;
-
-use crate::error::errorf;
+use crate::error::{errorf, DynamicResult};
 use crate::types::*;
 
-type ParseResult<T> = Result<T, Box<dyn Error>>;
-
 impl Schematic {
-    pub fn parse(p: &Path) -> ParseResult<Schematic> {
+    pub fn parse(p: &Path) -> DynamicResult<Schematic> {
         parse_schematic(p, String::new())
     }
 }
 
 /// Turns a KiCad schematic at `path` into a recursive Schematic struct
-fn parse_schematic(path: &Path, id: String) -> ParseResult<Schematic> {
+fn parse_schematic(path: &Path, id: String) -> DynamicResult<Schematic> {
     // Read the schematic using kicad_parse_gen
     let kisch = kicad_parse_gen::read_schematic(path)?;
 
@@ -37,7 +33,7 @@ fn parse_schematic(path: &Path, id: String) -> ParseResult<Schematic> {
 }
 
 /// Parses the metadata from the given KiCad schematic
-pub fn parse_meta(kisch: &kicad_schematic::Schematic, path: &Path) -> ParseResult<SchematicMeta> {
+pub fn parse_meta(kisch: &kicad_schematic::Schematic, path: &Path) -> DynamicResult<SchematicMeta> {
     // Only include non-empty comments
     let comments = vec![
         kisch.description.comment1.as_str(),
@@ -64,7 +60,7 @@ pub fn parse_meta(kisch: &kicad_schematic::Schematic, path: &Path) -> ParseResul
 }
 
 /// Parses global definitions from text notes in the KiCad schematic
-pub fn parse_globals(kisch: &kicad_schematic::Schematic) -> ParseResult<Vec<Attribute>> {
+pub fn parse_globals(kisch: &kicad_schematic::Schematic) -> DynamicResult<Vec<Attribute>> {
     let mut globals = Vec::new();
 
     // Loop through the elements of the schematic, which includes text notes as well
@@ -120,7 +116,7 @@ pub fn parse_globals(kisch: &kicad_schematic::Schematic) -> ParseResult<Vec<Attr
 }
 
 /// Parses the component definitions present in the given KiCad schematic
-pub fn parse_components(kisch: &kicad_schematic::Schematic) -> ParseResult<Vec<Component>> {
+pub fn parse_components(kisch: &kicad_schematic::Schematic) -> DynamicResult<Vec<Component>> {
     let mut components = Vec::new();
 
     // Walk through all components in the sheet
@@ -236,7 +232,7 @@ pub fn parse_components(kisch: &kicad_schematic::Schematic) -> ParseResult<Vec<C
 pub fn parse_sub_schematics(
     kisch: &kicad_schematic::Schematic,
     path: &Path,
-) -> ParseResult<Vec<Schematic>> {
+) -> DynamicResult<Vec<Schematic>> {
     let mut sub_schematics = Vec::new();
 
     // Recursively traverse and parse the sub-schematics

--- a/tools/kicad_rs/src/requirements.rs
+++ b/tools/kicad_rs/src/requirements.rs
@@ -1,0 +1,78 @@
+use crate::labels::{Labels, LabelsMatch};
+use serde::{Deserialize, Serialize};
+
+// Requirement specifies a requirement for a Labels key-value set.
+// The operator is the enum value, and the data to use for matching
+// is in the struct.
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+#[serde(tag = "op")]
+pub enum Requirement {
+    // At least one value
+    In { key: String, values: Vec<String> },
+    NotIn { key: String, values: Vec<String> },
+
+    // One value
+    Equals { key: String, values: [String; 1] },
+    NotEquals { key: String, values: [String; 1] },
+
+    // No values
+    Exists { key: String },
+    DoesNotExist { key: String },
+
+    // One numeric value
+    Gt { key: String, values: [f64; 1] },
+    Lt { key: String, values: [f64; 1] },
+}
+
+// Implement the LabelsMatch trait for a vector of requirements ANDed together
+impl LabelsMatch for Vec<Requirement> {
+    fn matches<L: Labels>(&self, labels: &L) -> bool {
+        self.iter().all(|r| r.matches(labels))
+    }
+}
+
+// Implement the LabelsMatch trait for a single requirement
+impl LabelsMatch for Requirement {
+    fn matches<L: Labels>(&self, labels: &L) -> bool {
+        match self {
+            Requirement::In { key, values } => Requirement::match_in(labels, key, values),
+            Requirement::NotIn { key, values } => !Requirement::match_in(labels, key, values),
+            Requirement::Equals { key, values } => Requirement::match_in(labels, key, values),
+            Requirement::NotEquals { key, values } => !Requirement::match_in(labels, key, values),
+            Requirement::Exists { key } => labels.get_label(key).is_some(),
+            Requirement::DoesNotExist { key } => labels.get_label(key).is_none(),
+            Requirement::Gt { key, values } => {
+                Requirement::match_numeric(labels, key, |n| n > values[0])
+            }
+            Requirement::Lt { key, values } => {
+                Requirement::match_numeric(labels, key, |n| n < values[0])
+            }
+        }
+    }
+}
+
+// Helper functions for the above matches function
+impl Requirement {
+    fn match_in<L>(labels: &L, key: &String, values: &[String]) -> bool
+    where
+        L: Labels,
+    {
+        labels
+            .get_label(key)
+            .map(|val| values.contains(&val.to_owned()))
+            .unwrap_or(false)
+    }
+    fn match_numeric<L, P>(labels: &L, key: &String, p: P) -> bool
+    where
+        L: Labels,
+        P: FnOnce(f64) -> bool,
+    {
+        labels
+            .get_label(key)
+            .map(|s| s.parse::<f64>().ok())
+            .flatten()
+            .map(|num| p(num))
+            .unwrap_or(false)
+    }
+}

--- a/tools/kicad_rs/src/types.rs
+++ b/tools/kicad_rs/src/types.rs
@@ -106,7 +106,7 @@ pub struct Attribute {
     pub comment: Option<String>,
 }
 
-// A vector of Attributes implement the Labels trait
+// A vector of Attributes implements the Labels trait
 impl Labels for Vec<Attribute> {
     fn get_label(&self, key: &str) -> Option<&str> {
         self.iter()

--- a/tools/kicad_rs/src/types.rs
+++ b/tools/kicad_rs/src/types.rs
@@ -4,36 +4,47 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct Schematic {
     // The "top-level" schematic has id ""
     pub id: String,
     pub meta: SchematicMeta,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub globals: Vec<Attribute>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub components: Vec<Component>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub sub_schematics: Vec<Schematic>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct SchematicMeta {
     pub file_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub date: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub revision: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub company: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub comments: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct Component {
     pub reference: String,
     pub footprint_name: String,
@@ -41,21 +52,27 @@ pub struct Component {
     pub symbol_name: String,
     pub symbol_library: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub datasheet: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub attributes: Vec<Attribute>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct Attribute {
     pub name: String,
     pub value: String,
     pub expression: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub unit: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub comment: Option<String>,
 }

--- a/tools/kicad_rs/src/types.rs
+++ b/tools/kicad_rs/src/types.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::iter::FromIterator;
 
+use crate::labels::Labels;
+
 // These types are used to structure the YAML-formatted output
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -102,4 +104,13 @@ pub struct Attribute {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub comment: Option<String>,
+}
+
+// A vector of Attributes implement the Labels trait
+impl Labels for Vec<Attribute> {
+    fn get_label(&self, key: &str) -> Option<&str> {
+        self.iter()
+            .find(|&a| a.name == key)
+            .map(|a| a.value.as_str())
+    }
 }

--- a/tools/kicad_rs/src/types.rs
+++ b/tools/kicad_rs/src/types.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::iter::FromIterator;
 
 // These types are used to structure the YAML-formatted output
 
@@ -46,6 +48,19 @@ pub struct SchematicMeta {
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct Component {
+    pub labels: ComponentLabels,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub classes: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    pub attributes: Vec<Attribute>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct ComponentLabels {
     pub reference: String,
     pub footprint_name: String,
     pub footprint_library: String,
@@ -57,9 +72,21 @@ pub struct Component {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub datasheet: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(default)]
-    pub attributes: Vec<Attribute>,
+    pub extra: HashMap<String, String>,
+}
+
+impl ComponentLabels {
+    pub fn to_map(&self) -> HashMap<&str, &str> {
+        let mut m = HashMap::from_iter(self.extra.iter().map(|s| (s.0.as_str(), s.1.as_str())));
+        m.insert("reference", self.reference.as_str());
+        m.insert("footprintLibrary", self.footprint_library.as_str());
+        m.insert("footprintName", self.footprint_name.as_str());
+        m.insert("symbolLibrary", self.symbol_library.as_str());
+        m.insert("symbolName", self.symbol_name.as_str());
+        m
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Commits:
- Prep work: move `DynamicResult` to `error.rs`, and improve `marshal_yaml` to write to a writer, not a string
- Refuse to unmarshal YAML if there are unknown fields (I spent quite some time with a typo in the YAML :sweat_smile:). Default optional fields so they can be unmarshalled without errors.
- Make it possible to annotate a component with a "generic" label, for potential use in a unix pipe by plugins
- Add a `Labels` trait similar to https://pkg.go.dev/k8s.io/apimachinery@v0.21.1/pkg/labels#Labels
- Add a `Requirement` enum similar to https://pkg.go.dev/k8s.io/apimachinery@v0.21.1/pkg/labels#NewRequirement
- Implement a classifier (as a separate binary) for components that assigns a `class` to components given other attributes

The sample data I used for `policy.yaml` is:
```yaml
classifiers:
- class: capacitor
  labels:
  - key: symbolName
    op: Equals
    values:
    - "C_Small"
- class: capacitor
  labels:
  - key: footprintLibrary
    op: Equals
    values:
    - Capacitor_SMD
- class: resistor
  labels:
  - key: symbolName
    op: Equals
    values:
    - R_Small
- class: shunt_resistor
  labels:
  - key: symbolName
    op: Equals
    values:
    - R_Small
  attributes:
  - key: Tolerance
    op: Equals
    values:
    - "1"
```

I used the Kubernetes API way of matching labels in order to be sure it's at least somewhat generic and battle-tested, instead of inventing my own thing. If you go and check the Go code implementing this in k8s, and compare to this implementation, one can see that Rust really shines for this task.

@chiplet @twelho 