### PR TITLE
Implement a typed value enum, and slightly change the get_label declaration

### DIFF
--- a/tools/kicad_rs/src/labels.rs
+++ b/tools/kicad_rs/src/labels.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 // Labels is a trait describing a string-string of labels describing some object
 pub trait Labels {
-    fn get_label(&self, key: &str) -> Option<&str>;
+    fn get_label(&self, key: &str) -> Option<String>;
 }
 
 // LabelsMatch is a trait that allows deciding whether a given requirement matches
@@ -13,7 +13,7 @@ pub trait LabelsMatch {
 
 // Implement the Labels trait for a string-string HashMap
 impl Labels for HashMap<&str, &str> {
-    fn get_label(&self, key: &str) -> Option<&str> {
-        self.get(key).map(|s| s.to_owned())
+    fn get_label(&self, key: &str) -> Option<String> {
+        self.get(key).map(|s| s.to_string())
     }
 }

--- a/tools/kicad_rs/src/parser.rs
+++ b/tools/kicad_rs/src/parser.rs
@@ -104,7 +104,7 @@ pub fn parse_globals(kisch: &kicad_schematic::Schematic) -> DynamicResult<Vec<At
             // Push the new attribute into the given vector
             globals.push(Attribute {
                 name: attr_name.into(),
-                value: String::new(), // TODO: How do we resolve this value?
+                value: String::new().into(), // TODO: How do we resolve this value?
                 expression: expr.into(),
                 unit: unit.map(|u| u.trim().into()),
                 comment: None,
@@ -191,7 +191,7 @@ pub fn parse_components(kisch: &kicad_schematic::Schematic) -> DynamicResult<Vec
                         .into()
                 },
                 // Get the main key value. It is ok if it's empty, too.
-                value: get_component_attr_mapped(&comp, main_key, &m).or_empty_str(),
+                value: Value::parse(get_component_attr_mapped(&comp, main_key, &m).or_empty_str()),
                 // As this field corresponds to the main key expression attribute, we can get the expression directly
                 expression: f.value.clone(),
                 // Optionally, get the unit and a comment


### PR DESCRIPTION
As discussed with @twelho. This allows us to have better type-safety when de/serializing as well.
The get_labels call is fixed to make life easier.