### PR TITLE
Support external parameters in the voltage divider

### DIFF
--- a/tools/kicad/kicad_functions/Cargo.toml
+++ b/tools/kicad/kicad_functions/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2018"
 
 [dependencies]
 evalexpr = "6.1"
+regex = "1.5"
 resistor-calc = { git = "https://github.com/racklet/resistor-calc.git", branch = "fix-no-expr_builder-compile", default-features = false }

--- a/tools/kicad/kicad_functions/src/lib.rs
+++ b/tools/kicad/kicad_functions/src/lib.rs
@@ -4,7 +4,7 @@ mod vdiv;
 
 use evalexpr::{EvalexprError, EvalexprResult, Value};
 
-// Match function for all custom functions available in the kicad_rs evaluator
+/// Matching function for all custom functions provided by the kicad_rs evaluator
 pub fn call_function(identifier: &str, argument: &Value) -> EvalexprResult<Value> {
     match identifier {
         "idx" => idx::index(argument),

--- a/tools/kicad/kicad_functions/src/vdiv.rs
+++ b/tools/kicad/kicad_functions/src/vdiv.rs
@@ -142,10 +142,10 @@ fn calculate(config: &VoltageDividerConfig) -> Option<RRes> {
 }
 
 /// `voltage_divider` computes values for resistor-based voltage dividers.
-/// - Usage: vdiv(<target voltage>, <divider expression>, <resistor series>,
-///               {(<min resistance>, <max resistance>)}, ({extra 1}, {extra 2}, ...))
+/// - Usage: vdiv(\<target voltage\>, \<divider expression\>, \<resistor series\>,
+///               {(\<min resistance\>, \<max resistance\>)}, ({extra 1}, {extra 2}, ...))
 /// - Example: vdiv(5.1, "(R1+R2)/R2*E1", "E96", (500e3, 700e3), (0.8))
-/// - Output: (<closest voltage>, <R1 value>, <R2 value>, ...)
+/// - Output: (\<closest voltage\>, \<R1 value\>, \<R2 value\>, ...)
 /// There can be arbitrary many resistors in the divider, but they must be named "R1", "R2", etc.
 /// The computed optimal resistance values are also presented in this order. The minimal and maximal
 /// resistance pair is an optional parameter, and the limits only consider the sum of resistance of


### PR DESCRIPTION
See the doc comments for the `voltage_divider` function for details. By passing external parameters as arguments to the `vdiv` function we can leverage the dependency resolving of the evaluator. The given parameters will subsequently be made available via `En` identifiers where `n` counts up from 1 (like is commonly done for resistors as well).

Completes the final task of #16.