### PR TITLE
Implement updating and exporting `kicad_parse_gen` Schematics for the evaluator

### DIFF
--- a/tools/kicad/kicad_functions/Cargo.toml
+++ b/tools/kicad/kicad_functions/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2018"
 
 [dependencies]
 evalexpr = "6.1"
+regex = "1.5"
 resistor-calc = { git = "https://github.com/racklet/resistor-calc.git", branch = "fix-no-expr_builder-compile", default-features = false }

--- a/tools/kicad/kicad_rs/src/parser.rs
+++ b/tools/kicad/kicad_rs/src/parser.rs
@@ -415,17 +415,26 @@ impl<T: AsRef<str>> SplitCharN for Option<T> {
     }
 }
 
+// OrDefault provides a way to substitute the default value of a variable. For
+// example, the default value of a &str type is "". If the caller equals this
+// default value, the returned value is replaced with the new passed-in default
+// of the same type, otherwise the current value of the caller is returned.
 trait OrDefault<'a, T> {
     fn or_default(self, default: T) -> T;
 }
 
+// OrDefault is implemented for all types that implement Default and PartialEq
+// (for comparing against their type-specific default). The built-in trait Default
+// allows fetching the default value to compare against, e.g. "" for string-like
+// types and 0 for number-like types as the respective type T.
 impl<'a, T: Default + PartialEq> OrDefault<'a, T> for T {
     fn or_default(self, default: T) -> T {
         if self == Default::default() {
+            // If the caller matches its own default, return the new given default instead
             return default;
         }
 
-        self
+        self // Otherwise return the current value of the caller
     }
 }
 

--- a/tools/kicad/kicad_rs/src/types.rs
+++ b/tools/kicad/kicad_rs/src/types.rs
@@ -28,7 +28,9 @@ pub struct Schematic {
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct SchematicMeta {
-    pub file_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub filename: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub title: Option<String>,


### PR DESCRIPTION
Bases on #17, crosses the last item off the list in #14. With this the `kicad_parse_gen::schematic::Schematic` structs are being properly kept track of and can finally be updated using the internal `Schematic` structs as well as written back to their respective files. Designed so that it should be easy to adapt to the changes in #15 once it gets merged.

`kicad_parse_gen` has a nasty bug with handling escaped strings, I've added the `escape`/`unescape` workaround just for the expression field for now, but since it is more widespread we might want to open an issue for it (and fix it) upstream.

cc @luxas @chiplet 