### PR TITLE
Post-CUE fixes and refinements to the evaluator

### DIFF
--- a/tools/kicad/kicad_functions/src/vdiv.rs
+++ b/tools/kicad/kicad_functions/src/vdiv.rs
@@ -88,6 +88,8 @@ impl VoltageDividerConfig {
     }
 }
 
+// TODO: Support u, k, M, G, etc. suffixes. Now the evaluator treats them as a variable.
+//  This can also be used to work around lacking support for negative exponents.
 fn calculate(config: &VoltageDividerConfig) -> Option<RRes> {
     let calc = RCalc::new(vec![config.series; config.count]);
 

--- a/tools/kicad/kicad_rs/src/eval/entry.rs
+++ b/tools/kicad/kicad_rs/src/eval/entry.rs
@@ -7,7 +7,6 @@ use std::cell::RefCell;
 #[derive(Debug)]
 pub struct Entry<'a> {
     set_in_progress: RefCell<bool>,
-    attr_name: &'a String,
     attribute: &'a mut Attribute,
     value: Option<Value>,
 }
@@ -26,10 +25,6 @@ fn expected_type(expected_type: &ValueType, actual: Value) -> EvalexprError {
 }
 
 impl<'a> Entry<'a> {
-    pub fn get_name(&self) -> &str {
-        self.attr_name
-    }
-
     pub fn get_expression(&self) -> &str {
         &self.attribute.expression
     }
@@ -59,7 +54,6 @@ impl<'a> Entry<'a> {
 
     pub fn value_defined(&self) -> DynamicResult<bool> {
         if *self.set_in_progress.borrow() {
-            // TODO: More precise error reporting
             return Err(errorf("dependency loop detected"));
         }
 
@@ -68,12 +62,11 @@ impl<'a> Entry<'a> {
     }
 }
 
-impl<'a> From<(&'a String, &'a mut Attribute)> for Entry<'a> {
-    fn from(attr_tuple: (&'a String, &'a mut Attribute)) -> Self {
+impl<'a> From<&'a mut Attribute> for Entry<'a> {
+    fn from(attribute: &'a mut Attribute) -> Self {
         Self {
             set_in_progress: RefCell::new(false),
-            attr_name: attr_tuple.0,
-            attribute: attr_tuple.1,
+            attribute,
             value: None,
         }
     }

--- a/tools/kicad/kicad_rs/src/eval/index.rs
+++ b/tools/kicad/kicad_rs/src/eval/index.rs
@@ -1,10 +1,8 @@
 use crate::eval::entry::Entry;
 use crate::eval::path::Path;
+use crate::parser::VALUE_FIELD_KEY;
 use evalexpr::{Context, ContextWithMutableVariables, EvalexprError, EvalexprResult, Value};
 use std::collections::HashMap;
-
-// The default attribute is signified by an empty string
-const DEFAULT_ATTR: String = String::new();
 
 pub type ComponentIndex<'a> = HashMap<String, Entry<'a>>;
 
@@ -36,7 +34,7 @@ impl<'a> SheetIndex<'a> {
                     if path.len() > 1 {
                         None // There's more elements, an incomplete path was given
                     } else {
-                        idx.get(path.next().unwrap_or(&DEFAULT_ATTR))
+                        idx.get(path.next().unwrap_or(&String::from(VALUE_FIELD_KEY)))
                     }
                 }
             })
@@ -58,7 +56,7 @@ impl<'a> SheetIndex<'a> {
                 if path.len() > 1 {
                     Err(err("component encountered during traversal"))
                 } else {
-                    idx.get_mut(path.next().unwrap_or(&DEFAULT_ATTR))
+                    idx.get_mut(path.next().unwrap_or(&String::from(VALUE_FIELD_KEY)))
                         .ok_or(err("attribute not found"))?
                         .update(value)
                 }

--- a/tools/kicad/kicad_rs/src/parser.rs
+++ b/tools/kicad/kicad_rs/src/parser.rs
@@ -5,6 +5,10 @@ use std::path::Path;
 use crate::error::{errorf, DynamicResult};
 use crate::types::*;
 
+// All symbols in Eeschema files have a mandatory value field which is used for the primary
+// unit of the component (i.e. resistance for a resistor, capacitance for a capacitor)
+pub(crate) const VALUE_FIELD_KEY: &str = "Value";
+
 // SchematicTree keeps track of all kicad_parse_gen
 // Schematics in a hierarchical schematic configuration
 #[derive(Debug)]
@@ -42,7 +46,7 @@ impl SchematicTree {
             self.schematic
                 .modify_component(&component.labels.reference, |c| {
                     for (attr_name, attribute) in component.attributes.iter() {
-                        let name = attr_name.as_str().or_default("Value");
+                        let name = attr_name.as_str().or_default(VALUE_FIELD_KEY);
                         c.update_field(name, &attribute.value.to_string());
                     }
                 })


### PR DESCRIPTION
So I spent the day thinking about and half-way rewriting the evaluator index to suit the new `HashMap`-based type system only to come to the conclusion that the current index system is still very optimal and required. The data stored and functionality provided by the `Entry` type is crucial for dependency loop detection, type validation and field formatting, and it does so in a very optimal way when indexed by the index implementation. In fact, the only real change needed was to change over to the default attribute field being `"Value"` instead of `""`, which was basically a one-line change :joy: I also realized that `Entry` doesn't need to reference the field name at all, which undoes most of the changes in `index_schematic`. Oh well, at least the source of dependency cycles is now indicated, and `cargo fmt` has been run for the project. Next things would be taking a look at fixing the parsing logic of `kicad_parse_gen` as well as implementing support for [metric prefixes](https://en.wikipedia.org/wiki/Metric_prefix).