### PR TITLE
Switch over to our `kicad_parse_gen` branch with fixed escaping

### DIFF
--- a/tools/kicad/kicad_rs/Cargo.toml
+++ b/tools/kicad/kicad_rs/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 evalexpr = "6.1"
 kicad_functions = { path = "../kicad_functions" }
-kicad_parse_gen = { git = "https://github.com/racklet/kicad-parse-gen", branch = "kicad5-escape-fix" }
+kicad_parse_gen = { git = "https://github.com/racklet/kicad-parse-gen" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"

--- a/tools/kicad/kicad_rs/Cargo.toml
+++ b/tools/kicad/kicad_rs/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 evalexpr = "6.1"
 kicad_functions = { path = "../kicad_functions" }
-kicad_parse_gen = { git = "https://github.com/productize/kicad-parse-gen", branch = "kicad5" }
+kicad_parse_gen = { git = "https://github.com/racklet/kicad-parse-gen", branch = "kicad5-escape-fix" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"

--- a/tools/kicad/kicad_rs/src/lib.rs
+++ b/tools/kicad/kicad_rs/src/lib.rs
@@ -1,8 +1,8 @@
-pub mod policy;
 pub mod codec;
 pub mod error;
 pub mod eval;
 pub mod labels;
 pub mod parser;
+pub mod policy;
 pub mod requirements;
 pub mod types;

--- a/tools/kicad/kicad_rs/src/policy.rs
+++ b/tools/kicad/kicad_rs/src/policy.rs
@@ -76,9 +76,7 @@ pub fn apply(cue_policy_file: &Path, sch: Schematic) -> DynamicResult<Schematic>
     // Marshal the now-classified Schematic back to YAML, inside the SchematicHolder struct
     // (to support arbitrary Schematic nesting) for piping to CUE defaulting and validation step
     let mut schematic_yaml: Vec<u8> = Vec::new();
-    let sch_holder = SchematicHolder{
-        schematic: sch,
-    };
+    let sch_holder = SchematicHolder { schematic: sch };
     codec::marshal_yaml(&sch_holder, &mut schematic_yaml)?;
 
     // Write the in-binary "map and reduction" CUE files to a temporary directory


### PR DESCRIPTION
PR against upstream: https://github.com/productize/kicad-parse-gen/pull/9. The last commit to upstream was in 2019, so the project seems to be a bit dormant right now. Thus, I propose switching over to our own fork where I've fixed the escaping (in [kicad5-escape-fix](https://github.com/racklet/kicad-parse-gen/tree/kicad5-escape-fix)) for now. This eliminates the need for the `escape` and `unescape` workarounds, as escaped characters are now correctly handled in the function responsible for input parsing in the library.

cc @luxas @chiplet 