### PR TITLE
Update `evalexpr`, use default branch for our `resistor-calc` fork

### DIFF
--- a/tools/kicad/kicad_functions/Cargo.toml
+++ b/tools/kicad/kicad_functions/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-evalexpr = "6.1"
+evalexpr = "6"
 regex = "1.5"
-resistor-calc = { git = "https://github.com/racklet/resistor-calc.git", branch = "fix-no-expr_builder-compile", default-features = false }
+resistor-calc = { git = "https://github.com/racklet/resistor-calc.git", default-features = false }

--- a/tools/kicad/kicad_rs/Cargo.toml
+++ b/tools/kicad/kicad_rs/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-evalexpr = "6.1"
+evalexpr = "6"
 kicad_functions = { path = "../kicad_functions" }
 kicad_parse_gen = { git = "https://github.com/racklet/kicad-parse-gen" }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Thanks to [ISibboI](https://github.com/ISibboI) for getting an `evalexpr` release with https://github.com/ISibboI/evalexpr/pull/87 out so quickly! Update the evaluator to use it right away, and also switch to the default branch for our `resistor-calc` fork.